### PR TITLE
Enhance Atlassian curl template with detailed instructions for adding…

### DIFF
--- a/templates/atlassian.curl.md
+++ b/templates/atlassian.curl.md
@@ -100,6 +100,85 @@ curl -X POST \
   }'
 ```
 
+#### Adding a Complex/Large Comment with ADF
+
+To add Jira comments with rich formatting (multiple paragraphs, lists, code blocks, etc.) using Atlassian Document Format (ADF), especially for large documents, ensure the following:
+
+1.  **Correct Payload Structure:** The JIRA API requires the entire ADF document to be nested within a JSON object, under a field named `"body"`. The JSON data sent to `curl` must conform to this structure:
+    ```json
+    // Example: jira_comment_payload.json
+    {
+      "body": { // This top-level "body" field is crucial
+        // --- Start of your Atlassian Document Format (ADF) object ---
+        "version": 1,
+        "type": "doc",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [
+              {
+                "type": "text",
+                "text": "This is the first paragraph of a potentially large comment."
+              }
+            ]
+          },
+          {
+            "type": "codeBlock",
+            "attrs": {
+              "language": "yaml"
+            },
+            "content": [
+              {
+                "type": "text",
+                "text": "key:\n  value: \"Some YAML content\"\n  # comments & special characters like '#' are correctly handled within here-documents or when read from a file."
+              }
+            ]
+          }
+          // ... more ADF nodes for your large comment ...
+        ]
+        // --- End of your Atlassian Document Format (ADF) object ---
+      }
+    }
+    ```
+
+2.  **Valid ADF Content:** The ADF object itself (the value for the top-level `"body"` field) must be syntactically correct. For complex or large documents, ensure all nodes, marks, and attributes adhere to the ADF specification. If you encounter `INVALID_INPUT` errors from JIRA, validating your ADF structure (e.g., using the Atlassian ADF Playground) can be helpful.
+
+3.  **Sending Large/Complex Data with `curl`:**
+    *   **Using a file (Recommended for large ADF):** This is the most reliable method for large or complex JSON payloads. Save the complete JSON structure (including the `{"body": ...}` wrapper) into a file (e.g., `jira_comment_payload.json`).
+        ```bash
+        curl -X POST \
+          https://your-domain.atlassian.net/rest/api/3/issue/ISSUE_KEY/comment \
+          -u $DIP_CONFLUENCE_EMAIL:$DIP_CONFLUENCE_TOKEN \
+          -H "Content-Type: application/json" \
+          -d @.jira_comment_payload.json # Use @ to specify the file path and start the name with "." so it's treated as a hidden file
+        ```
+    *   **Using a here-document (Alternative for multi-line JSON in scripts):**
+        This method allows embedding the JSON directly in a script or the command line and handles multi-line strings and special characters (like `#`) within the JSON content well.
+        ```bash
+        curl -X POST \
+          https://your-domain.atlassian.net/rest/api/3/issue/ISSUE_KEY/comment \
+          -u $DIP_CONFLUENCE_EMAIL:$DIP_CONFLUENCE_TOKEN \
+          -H "Content-Type: application/json" \
+          -d @- <<EOF 
+        { // Data starts on the next line
+          "body": {
+            "version": 1,
+            "type": "doc",
+            "content": [
+              // ... your full ADF content ...
+            ]
+          }
+        }
+        EOF // Closing delimiter must be on a new line, with no leading/trailing whitespace
+        ```
+
+4.  **Troubleshooting with `curl -i`:**
+    If JIRA returns an error, use the `-i` flag with `curl` to inspect the HTTP response headers and status code:
+    *   `HTTP 400` with `"INVALID_INPUT"` in the response body suggests the ADF content within the `"body"` field is malformed.
+    *   `HTTP 400` with `"Comment body can not be empty!"` in the response body indicates the top-level `"body"` field (which should wrap your ADF) is missing or the overall JSON payload structure is incorrect.
+
+Following these structural guidelines and using the file-based or here-document approach for `curl` will support posting large and complex ADF comments.
+
 ### Transition an Issue
 
 ```bash


### PR DESCRIPTION
This pull request updates the `templates/atlassian.curl.md` file to provide detailed instructions for adding complex or large comments to Jira issues using Atlassian Document Format (ADF). The changes include guidelines for payload structure, validation, and troubleshooting.

### Additions to Jira comment handling:

* **Guidelines for ADF Payload Structure**: Added instructions on structuring JSON payloads for Jira comments, emphasizing the importance of nesting the ADF document within a top-level `"body"` field.
* **Validation of ADF Content**: Included tips for ensuring ADF syntax correctness and troubleshooting `INVALID_INPUT` errors using tools like the Atlassian ADF Playground.
* **Methods for Sending Large JSON Payloads**:
  - Recommended using a file for large ADF payloads (`jira_comment_payload.json`).
  - Provided an alternative approach using here-documents for embedding JSON in scripts.
* **Troubleshooting with `curl -i`**: Explained how to diagnose common errors, such as malformed ADF content or missing `"body"` fields, by inspecting HTTP response headers and status codes.